### PR TITLE
adding a playbook for creating a tarball of volttron_home and volttro…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@ __pycache__/
 # vagrant files
 examples/.vagrant/*
 
-# Ansible builds
+# Ansible builds and outputs
 *.tgz
 *.tar.gz
+archives/*
 
 # C extensions
 *.so

--- a/backup.yml
+++ b/backup.yml
@@ -1,0 +1,24 @@
+---
+- name: backup platform
+  hosts: all
+  roles:
+  - volttron.deployment.set_defaults
+  vars:
+  - output_archive_name: /tmp/volttron_deployment_backup.tar.gz
+  - retrieve_archive: False
+  - retrieved_archive_dest_prefix: "archives/"
+
+  tasks:
+  - name: create archive of volttron home and root
+    archive:
+      path:
+      - "{{ volttron_home }}"
+      - "{{ volttron_root }}"
+      dest: "{{ output_archive_name }}"
+      format: gz
+  - name: retrieve archive
+    when: retrieve_archive | bool
+    fetch:
+      src: "{{ output_archive_name }}"
+      dest: "{{ retrieved_archive_dest_prefix }}/{{ inventory_hostname }}/"
+      flat: yes

--- a/backup.yml
+++ b/backup.yml
@@ -4,8 +4,11 @@
   roles:
   - volttron.deployment.set_defaults
   vars:
+  # by default, the archive is stored at this location (in the /temp dir of the remote)
   - output_archive_name: /tmp/volttron_deployment_backup.tar.gz
+  # if set to true, the archive will be pulled back to the system from which the playbook is run
   - retrieve_archive: False
+  # if pulled back, this variable configures where on the local system the archive will be pulled back to
   - retrieved_archive_dest_prefix: "archives/"
 
   tasks:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -139,6 +139,15 @@ desired running state. The default state is "running", but this is configurable 
 (and since variables can be set from the CLI, both starting and stopping are achievable without
 changing the playbook or inventory).
 
+Backup deployment
+~~~~~~~~~~~~~~~~~
+
+The ``backup.yml`` playbook will create a gzipped tar archive of the configured volttron root and home
+directories on the remote. The default behavior places the archive in the ``/tmp`` directory on the
+remote system, but setting the ``retrieve_archive`` variable to true will pull the archive back to the
+system from which the playbook is being run. See the ``vars`` section at the top of the playbook file
+for comments with more details.
+
 .. _recipe-example:
 
 Recipe examples


### PR DESCRIPTION
Adding another example playbook which will create a tarball of the volttron_ home and root dirs on a managed box, and optionally pull it back to the box from which the playbook is being run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron-ansible/13)
<!-- Reviewable:end -->
