### PR TITLE
Feature/use git module

### DIFF
--- a/roles/get_volttron_source/tasks/main.yml
+++ b/roles/get_volttron_source/tasks/main.yml
@@ -2,12 +2,25 @@
 ### It is only responsible for updating the source, not updating what is installed.
 ### (Though an editable pip install uses symbolic links and may still update in place)
 ---
+- name: check for replaced vctl
+  stat:
+    path: "{{ volttron_root }}/volttron/platform/.control.py.recipes.moved"
+  register: stashed_vctl
+- name: restore old vctl
+  when: stashed_vctl['stat']['exists']
+  copy:
+    remote_src: true
+    src: "{{ volttron_root }}/volttron/platform/.control.py.recipes.moved"
+    dest: "{{ volttron_root }}/volttron/platform/control.py"
+  changed_when: false
+
 - name: copy volttron source from github
   when: not volttron_use_local_source
   include: from-github.yml
 - name: copy local volttron source
   when: volttron_use_local_source
   include: from-local.yml
+
 - name: check vctl version
   stat:
     path: "{{ volttron_root }}/volttron/platform/control.py"
@@ -16,8 +29,15 @@
     msg:
     - "vctl hash is: {{ vctl_stat['stat']['checksum'] }}"
   when: verbose_debug_tasks | bool
-- name: replace vctl
-  when: vctl_stat['stat']['checksum'] == "d2369e903a82ba43732ff9cc58917094743a9c44"
+- name: stash old vctl
+  copy:
+    remote_src: true
+    src: "{{ volttron_root }}/volttron/platform/control.py"
+    dest: "{{ volttron_root }}/volttron/platform/.control.py.recipes.moved"
+  changed_when: false
+- name: replace vctl if needed
   copy:
     src: volttron.platform.control.py
     dest: "{{ volttron_root }}/volttron/platform/control.py"
+  when: vctl_stat['stat']['checksum'] == "d2369e903a82ba43732ff9cc58917094743a9c44"
+  changed_when: false

--- a/roles/set_defaults/tasks/main.yml
+++ b/roles/set_defaults/tasks/main.yml
@@ -43,7 +43,7 @@
     #  [bool] default: ``false``
     #    Enable the force flag when cloning and/or updating volttron root.
     #    If true, will discard any local changes to tracked files (but does retain untracked files).
-    volttron_git_force_clone: "{{ volttron_git_force_clone | default(True) }}"
+    volttron_git_force_clone: "{{ volttron_git_force_clone | default(False) }}"
 
     ## variables related to where volttron source and platform state are stored on the node
     ###


### PR DESCRIPTION
Modifies the git clone behavior to:
- always make a local hidden file copy of volttron control
- restore the volttron control file before doing a git update (this should mean there are no blocking changes on the local tree, assuming the user hasn't also made other changes
- allows the script to still report 'changed=0' on playbook runs that don't change the end state (unfortunately these cases aren't truly without changes: that is, they make a change and then revert it)

The only potentially problematic edge case here is if a user is deliberately trying to make their own local changes to control.py. If they want to do that however, they should make a fork and deploy a modified repo, not make changes in the board's source tree, so I think we're fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron-ansible/16)
<!-- Reviewable:end -->
