### PR TITLE
Fix install command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can install this collection directly from the [source repository](https://do
 That would typically look like:
 
 ```
-ansible-galaxy install git+https://github.com/volttron/volttron-ansible.git
+ansible-galaxy collection install git+https://github.com/volttron/volttron-ansible.git
 ```
 
 ## Documentation


### PR DESCRIPTION
Installing a collection requires the `collection` positional argument to `ansible-galaxy` else you install a bare role.

In addition to providing useful description, please ensure the following:

- [ ] If merging to main, bump the version in the galaxy.yml file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/volttron/volttron-ansible/21)
<!-- Reviewable:end -->
