### PR TITLE
feat: configure modular web service and rotating platform logs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -457,6 +457,38 @@ that are required, and the agent's configuration file and configuration store en
 that set is setting the initial running state of the agent, and whether or not it is enabled to
 autostart on platform start.
 
+Web configuration
+~~~~~~~~~~~~~~~~~
+
+The install platform recipe can install and configure the VOLTTRON web service. Web support is
+enabled by default and can be disabled in the platform configuration file::
+
+  config:
+    web-enabled: false
+
+When enabled, the role installs ``volttron-lib-tree`` and ``volttron-lib-web`` by default and writes
+the ``[web]`` section in ``$VOLTTRON_HOME/config``. The bind address defaults to localhost and can be
+overridden with ``bind-web-address``::
+
+  config:
+    web-enabled: true
+    bind-web-address: http://0.0.0.0:8443
+
+To create a web user for the admin UI or VUI REST API, provide both ``web-admin-user`` and
+``web-admin-password``. User creation is skipped when either value is omitted.
+
+.. code-block:: yaml
+
+  config:
+    web-enabled: true
+    bind-web-address: http://0.0.0.0:8443
+    web-admin-user: volttron-admin
+    web-admin-password: change-me
+
+The default web user groups are ``admin`` and ``vui``. Override them with ``web-admin-groups`` when
+needed. The generated web secret key is preserved across subsequent runs unless
+``web-secret-key`` is explicitly set.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/examples/vagrant-vms/web/web.yml
+++ b/examples/vagrant-vms/web/web.yml
@@ -1,2 +1,6 @@
 ---
-config: {}
+config:
+  web-enabled: true
+  bind-web-address: http://127.0.0.1:8443
+  web-admin-user: volttron-admin
+  web-admin-password: change-me

--- a/plugins/modules/volttron_platform.py
+++ b/plugins/modules/volttron_platform.py
@@ -42,7 +42,6 @@
 # docs here: https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html
 
 import os
-import psutil
 import subprocess
 import time
 
@@ -158,8 +157,11 @@ def check_pid(pid_file):
     is_running = False
     if os.path.exists(pid_file):
         pid = int(open(pid_file, 'r').read())
-        if psutil.pid_exists(pid):
+        try:
+            os.kill(pid, 0)
             is_running = True
+        except OSError:
+            is_running = False
     return is_running
 
 def execute_task(module):

--- a/roles/ansible_venv/tasks/main.yml
+++ b/roles/ansible_venv/tasks/main.yml
@@ -25,7 +25,6 @@
     virtualenv_command: "{{ ansible_python_interpreter }} -m venv"
     name:
     - pexpect
-    - psutil #required for volttron_platform module
   environment:
     http_proxy: "{{ http_proxy }}"
     https_proxy: "{{ https_proxy }}"

--- a/roles/install_platform/tasks/main.yml
+++ b/roles/install_platform/tasks/main.yml
@@ -39,6 +39,18 @@
     https_proxy: "{{ http_proxy }}"
   when: web_enabled | bool
 
+- name: ensure VOLTTRON_HOME exists
+  file:
+    path: "{{ volttron_home }}"
+    state: directory
+    mode: 0755
+
+- name: create VOLTTRON logging configuration
+  template:
+    src: logging-rotating.py.j2
+    dest: "{{ volttron_log_config }}"
+    mode: '0600'
+
 - name: create environment activation script
   template:
     src: activate-instance-env.j2
@@ -73,11 +85,6 @@
   become: true
 
 # configure the platform
-- name: ensure VOLTTRON_HOME exists
-  file:
-    path: "{{ volttron_home }}"
-    state: directory
-    mode: 0755
 - name: set instance name
   ini_file:
     path: "{{ volttron_home }}/config"

--- a/roles/install_platform/tasks/main.yml
+++ b/roles/install_platform/tasks/main.yml
@@ -141,6 +141,26 @@
   when: web_enabled | bool
   no_log: true
 
+- name: configure web ssl certificate
+  ini_file:
+    path: "{{ volttron_home }}/config"
+    section: web
+    option: web-ssl-cert
+    value: "{{ web_ssl_cert }}"
+    mode: '0600'
+    backup: yes
+  when: web_enabled | bool and web_ssl_cert | length > 0
+
+- name: configure web ssl key
+  ini_file:
+    path: "{{ volttron_home }}/config"
+    section: web
+    option: web-ssl-key
+    value: "{{ web_ssl_key }}"
+    mode: '0600'
+    backup: yes
+  when: web_enabled | bool and web_ssl_key | length > 0
+
 - name: copy web user setup script
   template:
     src: setup-web-user.py.j2

--- a/roles/install_platform/tasks/main.yml
+++ b/roles/install_platform/tasks/main.yml
@@ -29,6 +29,16 @@
     http_proxy: "{{ http_proxy }}"
     https_proxy: "{{ http_proxy }}"
 
+- name: install VOLTTRON web packages
+  pip:
+    virtualenv: "{{ volttron_venv }}"
+    virtualenv_command: "{{ python_interpreter }} -m venv"
+    name: "{{ web_packages }}"
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ http_proxy }}"
+  when: web_enabled | bool
+
 - name: create environment activation script
   template:
     src: activate-instance-env.j2
@@ -85,7 +95,7 @@
     mode: '0600'
     backup: yes
 - name: ensure platform configuration
-  loop: "{{ host_configuration.config | dict2items }}"
+  loop: "{{ host_configuration.config | dict2items | rejectattr('key', 'in', web_config_keys) | list }}"
   ini_file:
     path: "{{ volttron_home }}/config"
     section: volttron
@@ -93,6 +103,79 @@
     value: "{{ item.value }}"
     mode: '0600'
     backup: yes
+
+- name: read existing web secret key
+  command: >-
+    {{ volttron_venv }}/bin/python -c
+    "from configparser import ConfigParser; from pathlib import Path; c=ConfigParser(); c.read(Path('{{ volttron_home }}') / 'config'); print(c.get('web', 'web-secret-key', fallback=''))"
+  register: existing_web_secret_key
+  changed_when: false
+  failed_when: false
+  when: web_enabled | bool
+  no_log: true
+
+- name: choose web secret key
+  set_fact:
+    effective_web_secret_key: "{{ web_secret_key if (web_secret_key | length > 0) else ((existing_web_secret_key.stdout | default('')) if (existing_web_secret_key.stdout | default('') | length > 0) else lookup('password', '/dev/null length=43 chars=ascii_letters,digits')) }}"
+  when: web_enabled | bool
+  no_log: true
+
+- name: configure web bind address
+  ini_file:
+    path: "{{ volttron_home }}/config"
+    section: web
+    option: bind-web-address
+    value: "{{ web_bind_address }}"
+    mode: '0600'
+    backup: yes
+  when: web_enabled | bool
+
+- name: configure web secret key
+  ini_file:
+    path: "{{ volttron_home }}/config"
+    section: web
+    option: web-secret-key
+    value: "{{ effective_web_secret_key }}"
+    mode: '0600'
+    backup: yes
+  when: web_enabled | bool
+  no_log: true
+
+- name: copy web user setup script
+  template:
+    src: setup-web-user.py.j2
+    dest: "{{ volttron_home }}/setup-web-user.py"
+    mode: '0600'
+  changed_when: false
+  when:
+  - web_enabled | bool
+  - web_admin_user | length > 0
+  - web_admin_password | length > 0
+
+- name: create web admin user
+  command: "{{ volttron_venv }}/bin/python {{ volttron_home }}/setup-web-user.py"
+  environment:
+    VOLTTRON_HOME: "{{ volttron_home }}"
+    VOLTTRON_WEB_ADMIN_USER: "{{ web_admin_user }}"
+    VOLTTRON_WEB_ADMIN_PASSWORD: "{{ web_admin_password }}"
+    VOLTTRON_WEB_ADMIN_GROUPS: "{{ web_admin_groups | to_json }}"
+  register: web_admin_user_result
+  changed_when: "web_admin_user_result.stdout | trim == 'CHANGED'"
+  when:
+  - web_enabled | bool
+  - web_admin_user | length > 0
+  - web_admin_password | length > 0
+  no_log: true
+
+- name: remove web user setup script
+  file:
+    path: "{{ volttron_home }}/setup-web-user.py"
+    state: absent
+  changed_when: false
+  when:
+  - web_enabled | bool
+  - web_admin_user | length > 0
+  - web_admin_password | length > 0
 
 # For RMQ, do the extra config/bootstrapping/cert generation
 - name: rabbitmq configuration
@@ -122,4 +205,3 @@
     debug:
       msg: "{{ vcfg_result }}"
     failed_when: vcfg_result.failed
-

--- a/roles/install_platform/templates/logging-rotating.py.j2
+++ b/roles/install_platform/templates/logging-rotating.py.j2
@@ -1,0 +1,25 @@
+{
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'agent': {
+            '()': 'volttron.client.logs.AgentFormatter',
+            'format': '%(asctime)s %(composite_name)s(%(lineno)d) %(levelname)s: %(message)s',
+        },
+    },
+    'handlers': {
+        'rotating': {
+            'class': 'logging.handlers.RotatingFileHandler',
+            'level': 'DEBUG',
+            'formatter': 'agent',
+            'filename': {{ (volttron_log_file | regex_replace('^~', ansible_env.HOME)) | to_json }},
+            'maxBytes': {{ volttron_log_max_bytes }},
+            'backupCount': {{ volttron_log_backup_count }},
+            'encoding': 'utf-8',
+        },
+    },
+    'root': {
+        'handlers': ['rotating'],
+        'level': 'DEBUG',
+    },
+}

--- a/roles/install_platform/templates/setup-web-user.py.j2
+++ b/roles/install_platform/templates/setup-web-user.py.j2
@@ -1,0 +1,72 @@
+import json
+import os
+from pathlib import Path
+
+from passlib.hash import argon2
+import zmq
+
+volttron_home = Path(os.environ["VOLTTRON_HOME"]).expanduser()
+volttron_home.mkdir(parents=True, exist_ok=True)
+username = os.environ["VOLTTRON_WEB_ADMIN_USER"]
+password = os.environ["VOLTTRON_WEB_ADMIN_PASSWORD"]
+groups = json.loads(os.environ.get("VOLTTRON_WEB_ADMIN_GROUPS", "[]"))
+
+users_file = volttron_home / "web-users.json"
+users = json.loads(users_file.read_text()) if users_file.exists() else {}
+existing_user = users.get(username, {})
+existing_hash = existing_user.get("hashed_password")
+changed = (
+    not existing_hash
+    or not argon2.verify(password, existing_hash)
+    or existing_user.get("groups", []) != groups
+)
+if changed:
+    users[username] = {
+        "hashed_password": argon2.hash(password),
+        "groups": groups,
+    }
+    users_file.write_text(json.dumps(users, indent=2))
+    users_file.chmod(0o600)
+
+creds_dir = volttron_home / "credentials_store"
+creds_dir.mkdir(exist_ok=True)
+creds_file = creds_dir / "platform.web.json"
+if not creds_file.exists():
+    publickey, secretkey = [key.decode("ascii") for key in zmq.curve_keypair()]
+    creds_file.write_text(json.dumps({
+        "identity": "platform.web",
+        "publickey": publickey,
+        "secretkey": secretkey,
+        "domain": "",
+        "address": "",
+    }, indent=2))
+    creds_file.chmod(0o600)
+    changed = True
+
+authz_file = volttron_home / "authz.json"
+authz_data = json.loads(authz_file.read_text()) if authz_file.exists() else {
+    "roles": {},
+    "agents": {},
+    "agent_groups": {},
+}
+authz_data.setdefault("roles", {})
+authz_data.setdefault("agents", {})
+authz_data.setdefault("agent_groups", {})
+authz_data["agents"].setdefault("platform.web", {
+    "comments": "Automatically added by volttron-ansible for the web service"
+})
+
+admin_users = authz_data["agent_groups"].setdefault("admin_users", {})
+identities = set(admin_users.get("identities", []))
+identities.add("platform.web")
+admin_users["identities"] = sorted(identities)
+roles = set(admin_users.get("agent_roles", []))
+roles.add("admin")
+admin_users["agent_roles"] = sorted(roles)
+authz_before = authz_file.read_text() if authz_file.exists() else ""
+authz_after = json.dumps(authz_data, indent=2)
+if authz_before != authz_after:
+    authz_file.write_text(authz_after)
+    authz_file.chmod(0o600)
+    changed = True
+print("CHANGED" if changed else "UNCHANGED")

--- a/roles/install_platform/templates/start-volttron.j2
+++ b/roles/install_platform/templates/start-volttron.j2
@@ -5,6 +5,6 @@ SCRIPT_DIR="$( cd "$( echo "${BASH_SOURCE[0]%/*}" )" && pwd )"
 # Activate environment
 source "$SCRIPT_DIR/activate"
 
-echo "Starting VOLTTRON verbosely in the background"
-exec volttron -vv -l $VOLTTRON_HOME/volttron.log > /dev/null 2>&1 &
+echo "Starting VOLTTRON with rotating file logging in the background"
+exec volttron --log-config "{{ volttron_log_config }}" > /dev/null 2>&1 &
 disown

--- a/roles/install_platform/templates/volttron-installer.code-workspace
+++ b/roles/install_platform/templates/volttron-installer.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "../../../../volttron-installer"
+		},
+		{
+			"path": "../../.."
+		}
+	],
+	"settings": {}
+}

--- a/roles/install_platform/templates/volttron-service.j2
+++ b/roles/install_platform/templates/volttron-service.j2
@@ -19,7 +19,7 @@ StandardOutput=null
 StandardError=null
 #Uncomment and change this to specify a different VOLTTRON_HOME
 Environment="VOLTTRON_HOME={{volttron_home}}" "PATH={{volttron_venv}}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" "VIRTUAL_ENV={{volttron_venv}}"
-ExecStart={{volttron_venv}}/bin/python {{volttron_venv}}/bin/volttron -vv -l {{volttron_home}}/volttron.log
+ExecStart={{volttron_venv}}/bin/python {{volttron_venv}}/bin/volttron --log-config {{volttron_log_config}}
 ExecStop={{volttron_venv}}/bin/vctl shutdown --platform
 
 [Install]

--- a/roles/set_defaults/tasks/main.yml
+++ b/roles/set_defaults/tasks/main.yml
@@ -126,6 +126,21 @@
     auth_enabled: "{{host_configuration['config']['auth-enabled'] | default('False') }}"
     enable_federation: "{{host_configuration['config']['enable-federation'] | default('False') }}"
     federation_url: "{{host_configuration['config']['federation-url'] | default(omit) }}"
+    web_enabled: "{{ host_configuration['config']['web-enabled'] | default(True) }}"
+    web_bind_address: "{{ host_configuration['config']['bind-web-address'] | default('http://127.0.0.1:8443') }}"
+    web_secret_key: "{{ host_configuration['config']['web-secret-key'] | default('') }}"
+    web_admin_user: "{{ host_configuration['config']['web-admin-user'] | default('') }}"
+    web_admin_password: "{{ host_configuration['config']['web-admin-password'] | default('') }}"
+    web_admin_groups: "{{ host_configuration['config']['web-admin-groups'] | default(['admin', 'vui']) }}"
+    web_packages: "{{ host_configuration['config']['web-packages'] | default(['volttron-lib-tree', 'volttron-lib-web']) }}"
+    web_config_keys:
+    - web-enabled
+    - bind-web-address
+    - web-secret-key
+    - web-admin-user
+    - web-admin-password
+    - web-admin-groups
+    - web-packages
 
 - name: print all default VOLTTRON recipe facts
   debug:
@@ -149,4 +164,7 @@
     - "--- values determined from configuration files ---"
     - "messagebus {{ messagebus }}"
     - "instance_name {{ instance_name }}"
+    - "web_enabled {{ web_enabled }}"
+    - "web_bind_address {{ web_bind_address }}"
+    - "web_admin_user {{ web_admin_user }}"
   when: verbose_debug_tasks | bool

--- a/roles/set_defaults/tasks/main.yml
+++ b/roles/set_defaults/tasks/main.yml
@@ -133,6 +133,8 @@
     web_admin_password: "{{ host_configuration['config']['web-admin-password'] | default('') }}"
     web_admin_groups: "{{ host_configuration['config']['web-admin-groups'] | default(['admin', 'vui']) }}"
     web_packages: "{{ host_configuration['config']['web-packages'] | default(['volttron-lib-tree', 'volttron-lib-web']) }}"
+    web_ssl_cert: "{{ host_configuration['config']['web-ssl-cert'] | default('') }}"
+    web_ssl_key: "{{ host_configuration['config']['web-ssl-key'] | default('') }}"
     web_config_keys:
     - web-enabled
     - bind-web-address
@@ -141,6 +143,8 @@
     - web-admin-password
     - web-admin-groups
     - web-packages
+    - web-ssl-cert
+    - web-ssl-key
 
 - name: print all default VOLTTRON recipe facts
   debug:

--- a/roles/set_defaults/tasks/main.yml
+++ b/roles/set_defaults/tasks/main.yml
@@ -60,6 +60,15 @@
     #  [string - path] default: ``$HOME/.volttron/volttron.log``
     #    Path to the volttron log file.
     volttron_log_file: "{{ volttron_log_file | default('{{volttron_home}}/volttron.log') }}"
+    #  [string - path] default: ``$HOME/.volttron/logging-rotating.py``
+    #    Python logging configuration passed to VOLTTRON with --log-config.
+    volttron_log_config: "{{ volttron_log_config | default('{{volttron_home}}/logging-rotating.py') }}"
+    #  [integer] default: ``10485760``
+    #    Maximum size of the active VOLTTRON log file before rotation.
+    volttron_log_max_bytes: "{{ volttron_log_max_bytes | default(10485760) }}"
+    #  [integer] default: ``5``
+    #    Number of rotated VOLTTRON log files to retain.
+    volttron_log_backup_count: "{{ volttron_log_backup_count | default(5) }}"
     ###
     #  [string - path] default: ``$HOME/volttron.venv``
     #    path to the python virtual environment into which the VOLTTRON package will be installed


### PR DESCRIPTION
Add modular VOLTTRON web and VUI REST deployment support

This updates `volttron-ansible` to configure the modern modular VOLTTRON web stack directly from the platform config.

Code changes:

- Add web-related defaults in `roles/set_defaults/tasks/main.yml`:
  - `web_enabled`
  - `web_bind_address`
  - `web_secret_key`
  - `web_admin_user`
  - `web_admin_password`
  - `web_admin_groups`
  - `web_packages`
  - `web_config_keys`

- Install web packages in `roles/install_platform/tasks/main.yml` when web is enabled:
  - defaults to `volttron-lib-tree`
  - defaults to `volttron-lib-web`
  - package list can be overridden with `web-packages`

- Stop writing web-only config keys into the `[volttron]` section by filtering `web_config_keys`.

- Add `[web]` config management:
  - writes `bind-web-address`
  - writes `web-secret-key`
  - preserves an existing generated secret unless `web-secret-key` is explicitly configured

- Add `setup-web-user.py.j2` to create/update the web user:
  - writes `web-users.json`
  - creates `credentials_store/platform.web.json` when missing
  - updates `authz.json`
  - grants `platform.web` admin authorization
  - reports `CHANGED` or `UNCHANGED` for Ansible idempotency

- Add Ansible tasks to render, run, and remove the temporary web-user setup script when `web-admin-user` and `web-admin-password` are configured.

- Update `volttron_platform.py` to remove the `psutil` dependency:
  - replaces `psutil.pid_exists(pid)` with stdlib `os.kill(pid, 0)`

- Remove `psutil` from the helper Ansible venv package list because `volttron_platform.py` no longer needs it.

- Update docs and the web example config to show web/REST deployment settings.

Verification:

- Deployed a modular VOLTTRON instance.
- Confirmed systemd service creation and startup.
- Confirmed web bind address was active.
- Confirmed `/authenticate` returns JWTs for the configured web admin user.
- Confirmed authenticated `/vui/platforms` REST calls work.
- Confirmed `run_platforms` works without `psutil`.
- Confirmed reruns settle to idempotent `changed=0`.
